### PR TITLE
Allow more control over the arguments getting sent to lambda

### DIFF
--- a/src/lambda.coffee
+++ b/src/lambda.coffee
@@ -46,9 +46,11 @@ module.exports = (robot) ->
       params
     ).on("success", (response) ->
 
-      payload = JSON.parse(response.data.Payload)
-      msg.send payload
-      #console.log(response.data.StatusCode, response.data.Payload)
+      msg.send func + " invoked with " + payload
+
+      response_payload = JSON.parse(response.data.Payload)
+      msg.send response_payload
+      # console.log(response.data.StatusCode, response.data.Payload)
 
     ).on("error", (response) ->
       msg.send "error: " + response

--- a/src/lambda.coffee
+++ b/src/lambda.coffee
@@ -30,7 +30,7 @@ module.exports = (robot) ->
     args = msg.match[2]
 
     parsed_args = {}
-    args.replace /(\b[^:]+):([^\s]+)/g, ($0, param, value) ->
+    args.replace /([^\s:]+):([^\s]+)/g, ($0, param, value) ->
       parsed_args[param] = value
       return
 

--- a/src/lambda.coffee
+++ b/src/lambda.coffee
@@ -2,7 +2,7 @@
 #   Invokes an AWS Lambda function
 #
 # Commands:
-#   hubot lambda <function> <args>
+#   hubot lambda <function> <arg:value> <arg2:value> - Invokes an AWS lambda function with the given args
 #
 # Notes:
 #
@@ -27,9 +27,14 @@ module.exports = (robot) ->
   robot.respond /lambda ([a-zA-Z0-9-]+)\s?(.*)/i, (msg) ->
 
     func = msg.match[1]
-    arg1 = msg.match[2]
+    args = msg.match[2]
 
-    payload = JSON.stringify(message: arg1)
+    parsed_args = {}
+    args.replace /(\b[^:]+):([^\s]+)/g, ($0, param, value) ->
+      parsed_args[param] = value
+      return
+
+    payload = JSON.stringify(parsed_args)
 
     params =
       FunctionName: func

--- a/src/lambda.coffee
+++ b/src/lambda.coffee
@@ -7,7 +7,7 @@
 # Notes:
 #
 # Author:
-#   davemkirk@gmail.com   
+#   davemkirk@gmail.com
 
 region = process.env.HUBOT_LAMBDA_REGION ? "us-east-1"
 accessKeyId = process.env.HUBOT_LAMBDA_AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Allow for any arguments to be passed to the lambda function
Before, this was limited to lambda functions that are expecting `message` in the
events map.  However this assumption is not universal, and as such, should allow
the user to pass any arguments they want.

For example..

`hubot lambda function-name arg1:Yo arg2:Ho`

will send the following events dict to the lambda function

`{'arg1': 'Yo', 'arg2': 'Ho'}`